### PR TITLE
fix(accessibility): add lang attribute to html

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
   {% include head.html %}
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
   {% include head.html %}
 

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">


### PR DESCRIPTION
This PR adds a `lang` attribute of `en` to the `html` tags within the main page layouts. The `lang` attribute specifies what language the document has been written in, which can help certain screenreaders enable the right language features or voice for the document.

Awesome site, hope this helps. If it doesn't, no problem!

🌞 