### PR TITLE
feat(docs): use readme from latest published version instead of master

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -24,10 +24,13 @@
 
     <!-- Initializer -->
     <script>
-      Flatdoc.run({
-        fetcher: Flatdoc.github('yargs/yargs')
-      });
-
+      // use https://jsonp.afeld.me/ to wrap registry json in jsonp
+      $.get('https://jsonp.afeld.me/?url=https://registry.npmjs.org/yargs', function (data) {
+        var version = data['dist-tags'] && data['dist-tags'].latest
+        Flatdoc.run({
+          fetcher: Flatdoc.file('https://raw.githubusercontent.com/yargs/yargs/v' + version + '/README.md')
+        })
+      }, 'jsonp')
     </script>
   </head>
   <body role='flatdoc' class='no-literate'>


### PR DESCRIPTION
Same as yargs/yargs#542, see description there.

We should probably remove the gh-pages branch from the yargs repo while we're at it. 😃 