### PR TITLE
fix(docs): safeguard against jsonp service failures

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -24,13 +24,40 @@
 
     <!-- Initializer -->
     <script>
-      // use https://jsonp.afeld.me/ to wrap registry json in jsonp
-      $.get('https://jsonp.afeld.me/?url=https://registry.npmjs.org/yargs', function (data) {
-        var version = data['dist-tags'] && data['dist-tags'].latest
-        Flatdoc.run({
-          fetcher: Flatdoc.file('https://raw.githubusercontent.com/yargs/yargs/v' + version + '/README.md')
+      // use a service to wrap registry json in jsonp
+      var svcs = ['https://json2jsonp.com/', 'https://jsonp.afeld.me/']
+      var i = 0
+      var nextSvc = function () {
+        var svc = svcs[i++]
+        if (!svc) {
+          // no jsonp services worked, just use master
+          console.log('falling back to master branch :(')
+          return Flatdoc.run({
+            fetcher: Flatdoc.github('yargs/yargs')
+          })
+        }
+        $.ajax(svc, {
+          data: {
+            url: 'https://registry.npmjs.org/yargs'
+          },
+          dataType: 'jsonp',
+          timeout: 2000,
+          jsonpCallback: svc.replace(/\W/g, ''),
+          success: function (data) {
+            var version = data['dist-tags'] && data['dist-tags'].latest
+            if (!version) return nextSvc()
+            console.log('determined latest version as %s via %s', version, svc)
+            Flatdoc.run({
+              fetcher: Flatdoc.file('https://raw.githubusercontent.com/yargs/yargs/v' + version + '/README.md')
+            })
+          },
+          error: function () {
+            console.log('service failed: %s, trying next', svc)
+            nextSvc()
+          }
         })
-      }, 'jsonp')
+      }
+      nextSvc()
     </script>
   </head>
   <body role='flatdoc' class='no-literate'>


### PR DESCRIPTION
Our docs are currently unavailable because https://jsonp.afeld.me/ is down (CloudFlare returns a 521 response).

This hotfix uses the following fallbacks to account for this:

1. First try https://json2jsonp.com/ (slower but currently up)
2. If that fails, then try https://jsonp.afeld.me/ (faster but currently down)
3. If that fails, just use README from master branch

Because of the required used of jsonp, a "failure" is only detected via timeout (because a non-200 response would have to contain a jsonp-style callback in the body in order for an error handler to be called). Opted for a 2 second timeout b/c anything less might end up in false negative results (i.e. timeout) from json2jsonp.com.

Worst case scenario is two timeouts after 4 seconds and then loading docs from the master branch (which could be ahead of the latest release), but IMO this is better than not loading any docs at all.