### PR TITLE
added missing PT Serif font in docs section

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -18,6 +18,10 @@
     <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/theme-white/script.js'></script>
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
 
+    <!-- Fonts -->
+
+    <link href='https://fonts.googleapis.com/css?family=PT+Serif' rel='stylesheet' type='text/css'>
+
     <!-- Meta -->
     <meta content="yargs" property="og:title">
     <meta content="yargs the modern, pirate-themed successor to optimist." name="description">


### PR DESCRIPTION
I saw this on my machine in Firefox. 
![yargs](https://cloud.githubusercontent.com/assets/160328/19429084/0dbe57e4-944e-11e6-814b-b603db0b4728.png)

This pull request just includes the PT serif in the `<head>` section of the Docs as it doesn't use the same include as the main layout.