### PR TITLE
Suppress flatdoc's text-transform uppercase rule.

### DIFF
--- a/_sass/_docs.scss
+++ b/_sass/_docs.scss
@@ -8,6 +8,6 @@
   
   .content h2 {
     text-transform: none;
+    letter-spacing: initial;
   }
 }
-

--- a/_sass/_docs.scss
+++ b/_sass/_docs.scss
@@ -5,5 +5,9 @@
     will-change: transform;
     padding-top: 4em;
   }
+  
+  .content h2 {
+    text-transform: none;
+  }
 }
 


### PR DESCRIPTION
Addresses https://github.com/yargs/yargs.github.io/issues/37