### PR TITLE
Use https for ajax.googleapis.com to get jQuery

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -8,7 +8,7 @@
     <title>yargs</title>
 
     <!-- Flatdoc -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/legacy.js'></script>
     <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/flatdoc.js'></script>
 


### PR DESCRIPTION
I tried to browse https://yargs.js.org/docs/ but got a blank page. Probably because jQuery is loaded via http instead of https and browsers won't load http scripts on a https page. I was unable to test if this change would make it work, but using https is still a good idea.