### PR TITLE
Accessibility: Larger font sizes and higher contrast link color

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -91,16 +91,18 @@ h1, h2, h3, h4, h5, h6 {
 /**
  * Links
  */
-a {
-    color: $brand-color;
+a,
+.content-root a,
+.content-root .menu a {
+    color: $link-color;
     text-decoration: none;
 
     &:visited {
-        color: darken($brand-color, 15%);
+        color: darken($link-color, 15%);
     }
 
     &:hover {
-        color: $text-color;
+        color: lighten($link-color, 20%);
         text-decoration: underline;
     }
 }

--- a/_sass/_docs.scss
+++ b/_sass/_docs.scss
@@ -1,9 +1,11 @@
 .content-root {
+  font-size: 1.1rem;
+  color: $text-color;
   padding-top: 4em;
 
   div.menubar.fixed {
     will-change: transform;
-    padding-top: 4em;
+    padding-top: 75px;
   }
   
   .content h2 {

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -22,7 +22,7 @@
     padding-left: 2em;
     font-family: $base-font-family;
     font-weight: $base-font-weight;
-    font-size: 3em;
+    font-size: 3rem;
     float: left;
     color: $purple-color;
 
@@ -33,6 +33,7 @@
 }
 
 .site-logo {
+  font-size: 1.1rem;
   position: absolute;
   top: 0.4em;
   width: 7em;
@@ -40,6 +41,8 @@
 }
 
 .site-nav {
+    font-size: 1.1rem;
+    font-family: $base-font-family;
     float: right;
     line-height: 65px;
 
@@ -51,7 +54,7 @@
         line-height: $base-line-height;
         font-family: $base-font-family;
         color: $blue-color;
-        font-size: 1.5em;
+        font-size: 1.5rem;
 
         // Gaps between nav items, but not on the first one
         &:not(:first-child) {
@@ -220,7 +223,7 @@
 
 .page-title {
   font-weight: $base-font-weight;
-  font-size: 3em;
+  font-size: 3rem;
 }
 
 .post-list {

--- a/css/main.scss
+++ b/css/main.scss
@@ -18,7 +18,8 @@ $spacing-unit:     30px;
 
 $text-color:       #111;
 $background-color: #fdfdfd;
-$brand-color:      #0874df;
+$brand-color:      #0873dd;
+$link-color: #0754a2;
 
 $grey-color:       #828282;
 $light-grey:       #F2F1EF;


### PR DESCRIPTION
- Increase contrast of body link color to WCAG AAA level on white (fix #54)
- Increase size of text on docs page (fix #18)
- Adjust font sizes to address small font and layout inconsistencies between pages (side-effects from flatdoc CSS)