### PR TITLE
docs: made sidebar wider and don't wrap lines

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,8 +6,8 @@ title: Docs
 ---
 {% include header.html %}
 
-<div class='content-root'>
-  <div class='menubar'>
+<div class='content-root' style="padding-left: 400px">
+  <div class='menubar' style="width: 400px; white-space: nowrap">
     <div class='menu section' role='flatdoc-menu'></div>
   </div>
   <div role='flatdoc-content' class='content'></div>


### PR DESCRIPTION
This fixes issue https://github.com/yargs/yargs.github.io/issues/69

This PR makes the sidebar wider and disables line wrapping to make the list of functions more readable.

Attention: i do not have Ruby installed on my machine, so i have only tested this code directly in the browser, and haven't ran it from source code. If someone can test this from source, it would be appreciated.

Before:
![image](https://user-images.githubusercontent.com/1710840/215292475-d6d6a5e2-577f-4bba-9487-91f3399269b5.png)

After:
![image](https://user-images.githubusercontent.com/1710840/215292457-4f0a3129-ea02-4bcb-94b3-5169f44402ac.png)

