### PR TITLE
Fix two formatting issues on Contributing page

### DIFF
--- a/contributing/index.html
+++ b/contributing/index.html
@@ -22,23 +22,23 @@ title: Contributing
     <ol class="description">
 
       <li> Look through the existing issues and see if your idea is something new. </li>
-      <li> Create a <a href="https://github.com/yargs/yargs/issues"> new issue </a>, or comment on an existing issue that you would like to help solve:
+      <li> Create a <a href="https://github.com/yargs/yargs/issues">new issue</a>, or comment on an existing issue that you would like to help solve:
         <ul>
-          <li> it's usually best to get some feedback before proceeding to write code. ,</li>
+          <li> it's usually best to get some feedback before proceeding to write code.</li>
         </ul>
       </li>
 
       <li> fork the yargs repo, and clone it to your computer:
         <ul>
-          <li> GitHub has <a href="https://help.github.com/articles/using-pull-requests/"> great documentation </a> regarding writing your first pull request. </li>
+          <li> GitHub has <a href="https://help.github.com/articles/using-pull-requests/">great documentation</a> regarding writing your first pull request. </li>
         </ul>
       </li>
 
       <li> make sure that you write unit-test for any code that you write for yargs:
         <ul>
-          <li> we use <a href="https://github.com/feross/standard"> standard </a> coding style, which will validate your style when you run tests </li>
+          <li> we use <a href="https://github.com/feross/standard">standard</a> coding style, which will validate your style when you run tests </li>
 
-          <li> look through our extensive test suite in <a href="https://github.com/yargs/yargs/issues"> /test </a> to get an idea for how to write unit-tests for this codebase. </li>
+          <li> look through our extensive test suite in <a href="https://github.com/yargs/yargs/issues">/test</a> to get an idea for how to write unit-tests for this codebase. </li>
         </ul>
       </li>
 
@@ -107,8 +107,6 @@ title: Contributing
 
     <p class="description">
       This Code of Conduct is adapted from the <a href="http://contributor-covenant.org">Contributor Covenant</a>, version 1.3.0, available at <a href="http://contributor-covenant.org/version/1/3/0/">http://contributor-covenant.org/version/1/3/0/</a>
-
-
     </p>
 
   </div>


### PR DESCRIPTION
https://yargs.js.org/contributing/ had two visible issues:

- There was a space before the comma in “Create a new issue , or comment on an existing issue”. This was due to the practice of writing all `a` elements with inner spaces. I removed all such inner spaces to avoid this problem in the future.
- There was an unnecessary comma after a sentence: “write code. ,”

I also deleted some unnecessary blank lines at the bottom.

I did not try rebuilding the repo with Jekyll; I just edited this one file in the web editor. I don’t see any other source files for the Contributing page, though, so I think this should work.