### PR TITLE
fix(a11y): reducing 50% of a11y issues on contributor page

### DIFF
--- a/_sass/_contributing.scss
+++ b/_sass/_contributing.scss
@@ -9,4 +9,8 @@
     font-size: 1.2em;
     padding: 1em 0 0;
   }
+
+  a {
+    text-decoration: underline;
+  }
 }

--- a/contributing/index.html
+++ b/contributing/index.html
@@ -22,7 +22,7 @@ title: Contributing
     <ol class="description">
 
       <li> Look through the existing issues and see if your idea is something new. </li>
-      <li> Create a <a href="https://github.com/yargs/yargs/issues"> new issue</a>, or comment on an existing issue that you would like to help solve:
+      <li> Create a <a href="https://github.com/yargs/yargs/issues">new issue</a>, or comment on an existing issue that you would like to help solve:
         <ul>
           <li> it's usually best to get some feedback before proceeding to write code. ,</li>
         </ul>
@@ -30,15 +30,15 @@ title: Contributing
 
       <li> fork the yargs repo, and clone it to your computer:
         <ul>
-          <li> GitHub has <a href="https://help.github.com/articles/using-pull-requests/"> great documentation</a> regarding writing your first pull request. </li>
+          <li> GitHub has <a href="https://help.github.com/articles/using-pull-requests/">great documentation</a> regarding writing your first pull request. </li>
         </ul>
       </li>
 
       <li> make sure that you write unit-test for any code that you write for yargs:
         <ul>
-          <li> we use <a href="https://github.com/feross/standard"> standard</a> coding style, which will validate your style when you run tests </li>
+          <li> we use <a href="https://github.com/feross/standard">standard</a> coding style, which will validate your style when you run tests </li>
 
-          <li> look through our extensive test suite in <a href="https://github.com/yargs/yargs/issues"> /test</a> to get an idea for how to write unit-tests for this codebase. </li>
+          <li> look through our extensive test suite in <a href="https://github.com/yargs/yargs/issues">/test</a> to get an idea for how to write unit-tests for this codebase. </li>
         </ul>
       </li>
 

--- a/contributing/index.html
+++ b/contributing/index.html
@@ -22,7 +22,7 @@ title: Contributing
     <ol class="description">
 
       <li> Look through the existing issues and see if your idea is something new. </li>
-      <li> Create a <a href="https://github.com/yargs/yargs/issues"> new issue </a>, or comment on an existing issue that you would like to help solve:
+      <li> Create a <a href="https://github.com/yargs/yargs/issues"> new issue</a>, or comment on an existing issue that you would like to help solve:
         <ul>
           <li> it's usually best to get some feedback before proceeding to write code. ,</li>
         </ul>
@@ -30,15 +30,15 @@ title: Contributing
 
       <li> fork the yargs repo, and clone it to your computer:
         <ul>
-          <li> GitHub has <a href="https://help.github.com/articles/using-pull-requests/"> great documentation </a> regarding writing your first pull request. </li>
+          <li> GitHub has <a href="https://help.github.com/articles/using-pull-requests/"> great documentation</a> regarding writing your first pull request. </li>
         </ul>
       </li>
 
       <li> make sure that you write unit-test for any code that you write for yargs:
         <ul>
-          <li> we use <a href="https://github.com/feross/standard"> standard </a> coding style, which will validate your style when you run tests </li>
+          <li> we use <a href="https://github.com/feross/standard"> standard</a> coding style, which will validate your style when you run tests </li>
 
-          <li> look through our extensive test suite in <a href="https://github.com/yargs/yargs/issues"> /test </a> to get an idea for how to write unit-tests for this codebase. </li>
+          <li> look through our extensive test suite in <a href="https://github.com/yargs/yargs/issues"> /test</a> to get an idea for how to write unit-tests for this codebase. </li>
         </ul>
       </li>
 


### PR DESCRIPTION
## Description
Resolving issue #[78](https://github.com/yargs/yargs.github.io/issues/78) to make links on Yargs Contributor page accessible

## Before Changes
![before](https://github.com/yargs/yargs.github.io/assets/11414958/36d9669d-4061-4fe8-ba49-7f171928ffbf)

## After Changes
![after](https://github.com/yargs/yargs.github.io/assets/11414958/fa3fb1f2-fb5f-4217-b659-f71a50cbc5f2)

